### PR TITLE
fix(config): generate

### DIFF
--- a/build.go
+++ b/build.go
@@ -81,9 +81,13 @@ func Build(config Configuration,
 			config.NGINXConfLocation = filepath.Join(context.WorkingDir, config.NGINXConfLocation)
 		}
 
-		if config.WebServer == "nginx" {
-			err = configGenerator.Generate(config)
-			if err != nil {
+		var hasNGINXConf bool
+		if _, err := os.Stat(config.NGINXConfLocation); err == nil {
+			hasNGINXConf = true
+		}
+
+		if config.WebServer == "nginx" && !hasNGINXConf {
+			if err := configGenerator.Generate(config); err != nil {
 				return packit.BuildResult{}, fmt.Errorf("failed to generate nginx.conf : %w", err)
 			}
 		}
@@ -94,11 +98,6 @@ func Build(config Configuration,
 			if err != nil && errors.Is(err, os.ErrNotExist) {
 				return packit.BuildResult{}, fmt.Errorf("file %s (BP_WEB_SERVER_INCLUDE_FILE_PATH) doesn't exist within app dir", config.WebServerIncludeFilePath)
 			}
-		}
-
-		var hasNGINXConf bool
-		if _, err := os.Stat(config.NGINXConfLocation); err == nil {
-			hasNGINXConf = true
 		}
 
 		if hasNGINXConf {

--- a/default_config_generator_test.go
+++ b/default_config_generator_test.go
@@ -2,8 +2,6 @@ package nginx_test
 
 import (
 	"bytes"
-	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -360,18 +358,18 @@ error_log stderr;
 `)))
 		})
 
-		context("failure cases", func() {
-			context("destination file already exists and it's read-only", func() {
-				it.Before(func() {
-					Expect(os.WriteFile(filepath.Join(workingDir, "nginx.conf"), []byte("read-only file"), 0444)).To(Succeed())
-				})
-				it("returns an error", func() {
-					err := generator.Generate(nginx.Configuration{
-						NGINXConfLocation: filepath.Join(workingDir, "nginx.conf"),
-					})
-					Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("failed to create %[1]s: open %[1]s: permission denied", filepath.Join(workingDir, "nginx.conf")))))
-				})
-			})
-		})
+		// context("failure cases", func() {
+		// 	context("destination file already exists and it's read-only", func() {
+		// 		it.Before(func() {
+		// 			Expect(os.WriteFile(filepath.Join(workingDir, "nginx.conf"), []byte("read-only file"), 0444)).To(Succeed())
+		// 		})
+		// 		it("returns an error", func() {
+		// 			err := generator.Generate(nginx.Configuration{
+		// 				NGINXConfLocation: filepath.Join(workingDir, "nginx.conf"),
+		// 			})
+		// 			Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("failed to create %[1]s: open %[1]s: permission denied", filepath.Join(workingDir, "nginx.conf")))))
+		// 		})
+		// 	})
+		// })
 	})
 }


### PR DESCRIPTION
don't overwrite nginx.conf if it already exists.

this is an alternative to #975 with the failure test case disabled
as it shouldn't hit that anymore. the test kind of suggests that
overwriting the nginx.conf is "okay", which I would argue is a bug.

related: #667

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
