### PR TITLE
minor: Add dependency constraints for nginx 1.30.x and 1.31.x

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -12,7 +12,7 @@ api = "0.7"
   include-files = ["buildpack.toml", "linux/amd64/bin/build", "linux/amd64/bin/detect", "linux/amd64/bin/run", "linux/arm64/bin/configure", "linux/arm64/bin/build", "linux/arm64/bin/detect", "linux/arm64/bin/run", "linux/amd64/bin/configure"]
   pre-package = "./scripts/build.sh --target linux/amd64 --target linux/arm64"
   [metadata.default-versions]
-    nginx = "1.29.*"
+    nginx = "1.31.*"
 
   [[metadata.dependencies]]
     arch = "amd64"
@@ -269,6 +269,16 @@ api = "0.7"
     stacks = ["io.buildpacks.stacks.noble"]
     uri = "https://artifacts.paketo.io/nginx/nginx_1.28.3_linux_arm64_noble_2af64c15.tgz"
     version = "1.28.3"
+    
+  [[metadata.dependency-constraints]]
+    constraint = "1.31.*"
+    id = "nginx"
+    patches = 2
+
+  [[metadata.dependency-constraints]]
+    constraint = "1.30.*"
+    id = "nginx"
+    patches = 2
 
   [[metadata.dependency-constraints]]
     constraint = "1.29.*"
@@ -280,8 +290,8 @@ api = "0.7"
     id = "nginx"
     patches = 2
   [metadata.version-lines]
-    mainline = "1.29.*"
-    stable = "1.28.*"
+    mainline = "1.31.*"
+    stable = "1.30.*"
 
 [[stacks]]
   id = "io.buildpacks.stacks.jammy"

--- a/integration/logging_test.go
+++ b/integration/logging_test.go
@@ -58,10 +58,10 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 				fmt.Sprintf("%s 1.2.3", settings.Buildpack.Name),
 				"  Resolving Nginx Server version",
 				"    Candidate version sources (in priority order):",
-				`      buildpack.yml -> "1.29.*"`,
+				`      buildpack.yml -> "1.31.*"`,
 			))
 			Expect(logs).To(matchers.ContainLines(
-				MatchRegexp(`    Selected Nginx Server version \(using buildpack\.yml\): 1\.29\.\d+`),
+				MatchRegexp(`    Selected Nginx Server version \(using buildpack\.yml\): 1\.31\.\d+`),
 			))
 			Expect(logs).To(matchers.ContainLines(
 				"    WARNING: Setting the server version through buildpack.yml will be deprecated soon in Nginx Server Buildpack v2.0.0.",
@@ -99,11 +99,11 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 				fmt.Sprintf("%s 1.2.3", settings.Buildpack.Name),
 				"  Resolving Nginx Server version",
 				"    Candidate version sources (in priority order):",
-				`      BP_NGINX_VERSION -> "1.28.*"`,
-				`      buildpack.yml    -> "1.29.*"`,
+				`      BP_NGINX_VERSION -> "1.30.*"`,
+				`      buildpack.yml    -> "1.31.*"`,
 			))
 			Expect(logs).To(matchers.ContainLines(
-				MatchRegexp(`    Selected Nginx Server version \(using BP_NGINX_VERSION\): 1\.28\.\d+`),
+				MatchRegexp(`    Selected Nginx Server version \(using BP_NGINX_VERSION\): 1\.30\.\d+`),
 			))
 			Expect(logs).To(matchers.ContainLines(
 				"  Executing build process",


### PR DESCRIPTION
## Summary

nginx 1.30 (stable) and 1.31 (mainline) have been released but the
retrieve workflow has no constraints for them, so new versions are
silently ignored. Add constraints with patches=2 for both lines and
update default-versions and version-lines to track 1.31.* as mainline
and 1.30.* as stable.

Fixes: nginx 1.29 and 1.28 are now EOL; all 10 CVEs fixed in 1.31.0–1.31.3
Closes #1276

## Use Cases
The upgrade and workflow errors are caused by the configuration not recognizing the latest nginx versions. This PR fixes it and enables nginx to be upgraded to 1.31.x

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
